### PR TITLE
Eth2 py3.8 fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
 
 workflows:
   version: 2
@@ -62,3 +68,4 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core

--- a/setup.py
+++ b/setup.py
@@ -8,22 +8,20 @@ from setuptools import (
 import subprocess
 
 test_deps = [
-    'pytest>=3.6',
-    'pytest-cov==2.4.0',
-    'coveralls[yaml]==1.6.0',
-    'pytest-xdist==1.18.1',
-    'py-evm==0.2.0a42',
-    'eth-tester==0.1.0b39',
-    'eth-abi==2.0.0b9',
-    'web3==5.0.0b2',
+    'pytest>=5.2.0,<6',
+    'pytest-cov>=2.8.1,<3',
+    'coveralls[yaml]>=1.8.2,<2',
+    'pytest-xdist>=1.30.0,<2',
+    'eth-tester[py-evm]==0.1.0b39',
+    'web3>=5.2.0,<5.3.0',
     'tox>=3.7,<4',
-    'hypothesis==4.11.7'
+    'hypothesis>=4.41.3,<5'
 ]
 lint_deps = [
     'flake8>=3.7,<4',
-    'flake8-bugbear==18.8.0',
+    'flake8-bugbear>=19.8.0,<20',
     'isort>=4.2.15,<5',
-    'mypy==0.701',
+    'mypy>=0.740,<1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ test_deps = [
     'pytest-cov>=2.8.1,<3',
     'coveralls[yaml]>=1.8.2,<2',
     'pytest-xdist>=1.30.0,<2',
-    'eth-tester[py-evm]==0.1.0b39',
+    'eth-tester[py-evm]>=0.3.0b1,<0.4',
     'web3>=5.2.0,<5.3.0',
     'tox>=3.7,<4',
     'hypothesis>=4.41.3,<5'

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -55,11 +55,11 @@ def test_abort(w3, assert_tx_failed, get_balance, get_contract, contract_code):
     # Only sender can trigger refund
     assert_tx_failed(lambda: c.abort(transact={'from': a2}))
     # Refund works correctly
-    c.abort(transact={'from': a0, 'gasPrice': 0})
+    c.abort(transact={'from': a0})
     assert get_balance() == (a0_pre_bal, a1_pre_bal)
     # Purchase in process, no refund possible
     c = get_contract(contract_code, value=2)
-    c.purchase(transact={'value': 2, 'from': a1, 'gasPrice': 0})
+    c.purchase(transact={'value': 2, 'from': a1})
     assert_tx_failed(lambda: c.abort(transact={'from': a0}))
 
 
@@ -71,7 +71,7 @@ def test_purchase(w3, get_contract, assert_tx_failed, get_balance, contract_code
     assert_tx_failed(lambda: c.purchase(transact={'value': 1, 'from': a1}))
     assert_tx_failed(lambda: c.purchase(transact={'value': 3, 'from': a1}))
     # Purchase for the correct price
-    c.purchase(transact={'value': 2, 'from': a1, 'gasPrice': 0})
+    c.purchase(transact={'value': 2, 'from': a1})
     # Check if buyer is set correctly
     assert c.buyer() == a1
     # Check if contract is locked correctly
@@ -87,13 +87,13 @@ def test_received(w3, get_contract, assert_tx_failed, get_balance, contract_code
     init_bal_a0, init_bal_a1 = get_balance()
     c = get_contract(contract_code, value=2)
     # Can only be called after purchase
-    assert_tx_failed(lambda: c.received(transact={'from': a1, 'gasPrice': 0}))
+    assert_tx_failed(lambda: c.received(transact={'from': a1}))
     # Purchase completed
-    c.purchase(transact={'value': 2, 'from': a1, 'gasPrice': 0})
+    c.purchase(transact={'value': 2, 'from': a1})
     # Check that e.g. sender cannot trigger received
-    assert_tx_failed(lambda: c.received(transact={'from': a0, 'gasPrice': 0}))
+    assert_tx_failed(lambda: c.received(transact={'from': a0}))
     # Check if buyer can call receive
-    c.received(transact={'from': a1, 'gasPrice': 0})
+    c.received(transact={'from': a1})
     # Final check if everything worked. 1 value has been transferred
     assert get_balance() == (init_bal_a0 + 1, init_bal_a1 - 1)
 
@@ -144,7 +144,6 @@ def __default__():
     )
     # Start purchase
     buyer_contract.start_purchase(transact={
-        'gasPrice': 0,
         'value': 4,
         'from': w3.eth.accounts[1],
         'gas': 100000,
@@ -155,7 +154,6 @@ def __default__():
     # Trigger "re-entry"
     buyer_contract.start_received(transact={
         'from': w3.eth.accounts[1],
-        'gasPrice': 0,
         'gas': 100000,
     })
 

--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -46,6 +46,15 @@ x: int128(wei >> 3)
     """
 Transfer: event({_&rom: indexed(address)})
     """,
+    """
+@public
+def test() -> uint256:
+    for i in range(0, 4):
+      return 0
+    else:
+      return 1
+    return 1
+    """
 ]
 
 

--- a/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
+++ b/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
@@ -10,7 +10,7 @@ from vyper.parser.pre_parser import (
 
 class AssertionVisitor(python_ast.NodeVisitor):
     def assert_about_node(self, node):
-        assert False
+        raise AssertionError()
 
     def generic_visit(self, node):
         self.assert_about_node(node)

--- a/tests/parser/types/numbers/test_sqrt.py
+++ b/tests/parser/types/numbers/test_sqrt.py
@@ -142,6 +142,13 @@ def test(a: decimal) -> decimal:
     return c
 
 
+@pytest.mark.parametrize('value', [Decimal(0), Decimal(SizeLimits.MAXNUM)])
+def test_sqrt_bounds(sqrt_contract, value):
+    vyper_sqrt = sqrt_contract.test(value)
+    actual_sqrt = decimal_sqrt(value)
+    assert vyper_sqrt == actual_sqrt
+
+
 @hypothesis.given(
     value=hypothesis.strategies.decimals(
         min_value=Decimal(0),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37}-core
+    py{36,37,38}-core
     lint
 
 [flake8]
@@ -37,6 +37,7 @@ commands =
 basepython =
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 extras =
     test
 whitelist_externals = make

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -117,7 +117,7 @@ class keyword(VyperNode):
 
 
 class Str(VyperNode):
-    __slots__ = ('s', )
+    __slots__ = ('s', 'value')
 
 
 class Compare(VyperNode):
@@ -125,7 +125,7 @@ class Compare(VyperNode):
 
 
 class Num(VyperNode):
-    __slots__ = ('n', )
+    __slots__ = ('n', 'value')
 
 
 class NameConstant(VyperNode):

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -117,7 +117,7 @@ class keyword(VyperNode):
 
 
 class Str(VyperNode):
-    __slots__ = ('s', 'value')
+    __slots__ = ('s', )
 
 
 class Compare(VyperNode):
@@ -125,7 +125,7 @@ class Compare(VyperNode):
 
 
 class Num(VyperNode):
-    __slots__ = ('n', 'value')
+    __slots__ = ('n', )
 
 
 class NameConstant(VyperNode):
@@ -258,6 +258,7 @@ class Assert(VyperNode):
 
 class For(VyperNode):
     __slots__ = ('iter', 'target', 'body')
+    only_empty_fields = ('orelse', )
 
 
 class AugAssign(VyperNode):

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -4,7 +4,7 @@ from itertools import (
 import typing
 
 from vyper.exceptions import (
-    CompilerPanic,
+    SyntaxException,
 )
 from vyper.settings import (
     VYPER_ERROR_CONTEXT_LINES,
@@ -43,9 +43,9 @@ class VyperNode:
             if field_name in self.get_slots():
                 setattr(self, field_name, value)
             elif value:
-                raise CompilerPanic(
-                    f'Unsupported non-empty value field_name: {field_name}, '
-                    f' class: {type(self)} value: {value}'
+                raise SyntaxException(
+                    f'Unsupported non-empty value (valid in Python, but invalid in Vyper) \n'
+                    f' field_name: {field_name}, class: {type(self)} value: {value}'
                 )
 
     def __eq__(self, other):

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -257,7 +257,7 @@ class Assert(VyperNode):
 
 
 class For(VyperNode):
-    __slots__ = ('iter', 'target', 'orelse', 'body')
+    __slots__ = ('iter', 'target', 'body')
 
 
 class AugAssign(VyperNode):

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -76,18 +76,16 @@ def parse_python_ast(source_code: str,
     if isinstance(node, list):
         return _build_vyper_ast_list(source_code, node, source_id)
     elif isinstance(node, python_ast.AST):
-        # necessary for python3.8 compatibility
-        if isinstance(node, python_ast.Num):
-            class_name = "Num"
-        elif isinstance(node, python_ast.Str):
-            class_name = "Str"
-        elif isinstance(node, python_ast.Bytes):
-            class_name = "Bytes"
-        elif isinstance(node, python_ast.NameConstant):
-            class_name = "NameConstant"
-        else:
-            class_name = node.__class__.__name__
-
+        class_name = node.__class__.__name__
+        if isinstance(node, python_ast.Constant):
+            if isinstance(node.value, (int, float)):
+                class_name = "Num"
+            elif isinstance(node.value, str):
+                class_name = "Str"
+            elif isinstance(node.value, bytes):
+                class_name = "Bytes"
+            elif node.value is None or isinstance(node.value, bool):
+                class_name = "NameConstant"
         if not hasattr(vyper_ast, class_name):
             raise SyntaxException(
                 f'Invalid syntax (unsupported "{class_name}" Python AST node).', node

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -87,7 +87,19 @@ def parse_python_ast(source_code: str,
     if isinstance(node, list):
         return _build_vyper_ast_list(source_code, node, source_id)
     elif isinstance(node, python_ast.AST):
-        class_name = node.__class__.__name__
+        if isinstance(node, python_ast.Num):
+            class_name = "Num"
+            node._fields += ('n',)
+        elif isinstance(node, python_ast.Str):
+            class_name = "Str"
+            node._fields += ('s',)
+        elif isinstance(node, python_ast.Bytes):
+            class_name = "Bytes"
+            node._fields += ('s',)
+        elif isinstance(node, python_ast.NameConstant):
+            class_name = "NameConstant"
+        else:
+            class_name = node.__class__.__name__
         if hasattr(vyper_ast, class_name):
             vyper_class = getattr(vyper_ast, class_name)
             init_kwargs = _build_vyper_ast_init_kwargs(

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -80,14 +80,14 @@ def parse_python_ast(source_code: str,
 
     class_name = node.__class__.__name__
     if isinstance(node, python_ast.Constant):
-        if isinstance(node.value, (int, float)):
+        if node.value is None or isinstance(node.value, bool):
+            class_name = "NameConstant"
+        elif isinstance(node.value, (int, float)):
             class_name = "Num"
         elif isinstance(node.value, str):
             class_name = "Str"
         elif isinstance(node.value, bytes):
             class_name = "Bytes"
-        elif node.value is None or isinstance(node.value, bool):
-            class_name = "NameConstant"
     if not hasattr(vyper_ast, class_name):
         raise SyntaxException(f'Invalid syntax (unsupported "{class_name}" Python AST node).', node)
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1210,7 +1210,7 @@ z: decimal = 0.0
 if x == 0.0:
     z = 0.0
 else:
-    z = (x + 1.0) / 2.0
+    z = x / 2.0 + 0.5
     y: decimal = x
 
     for i in range(256):

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -169,7 +169,7 @@ class GlobalContext:
             for interface_name, sigs in global_ctx._interfaces.items():
                 if interface_name in global_ctx._implemented_interfaces:
                     for func_sig in sigs:
-                        setattr(func_sig, 'defined_in_interface', interface_name)
+                        func_sig.defined_in_interface = interface_name
                         global_ctx._interface[func_sig.sig] = func_sig
 
         # Add getters to _defs

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -534,7 +534,7 @@ class Stmt(object):
                 "..` or `for i in range(start, start + rounds): ..`"
             ), self.stmt.iter)
 
-        block_scope_id = id(self.stmt.orelse)
+        block_scope_id = id(self.stmt)
         with self.context.make_blockscope(block_scope_id):
             # Get arg0
             arg0 = self.stmt.iter.args[0]


### PR DESCRIPTION
What it looks like to make the previously pinned eth2 deposit-contract branch python 3.8 compatible, producing the same bytecode (please do double verify this).

To reproduce:
```bash

# After a lot of digging through git histories, and re-running the deposit contract compiler and vyper test suite:
#  this cherry-picks beta 14 and beta 15 features to make the contract setup python 3.8 compatible.
# Feedback to @protolambda

git checkout 1761-HOTFIX-v0.1.0-beta.13
git checkout -b eth2-py3.8-fix

# PR #1633: Remove for orelse for For
# -> python 3.8 PR required this
git cherry-pick -S 961ba88599ec1dfcc13b4c747745cfc0a4861333^..ca87ae213713fbad6e2c9b8d3386cc0e88292bac

# PR #1646: Upgraded depedencies
# -> long overdue test framework updates
git cherry-pick -S 70b9f8fb60f6aa7eb2418cb19b09d52985e66f66^..0e34605af7bbc39aec4ba5cc98a833f0cfa77468

# PR #1679: Avoid overflow on sqrt of Decimal upper bound
# -> fixes failing test
git cherry-pick -S a5d7ff438ee4c7d539d7573e2bb3541df4b052e9^..f0689901d8679df2205454d795bbf1ba99bd00b4

# PR #1678: Add support for Python3.8 (split in two to avoid merge commit)
# -> Essential for python 3.8 to work
git cherry-pick -S 78da2e6b4d8da6ff16d91d110f9433021e9e193b^..e78a1adeae05fd6d04cfadae022bc9a888338175
git cherry-pick -S cee9576ac0b9436e8c09135e9727d4989da0d2d1^..1c6671285699beb8da93b6d170769e3724dacc65

# PR #1657: eth-tester upgrade
# -> includes test framework fix to make "ecmul"
#  This was broken by "Potentially insufficient gas stipend for precompiled contract calls" #1761 (which was backported onto beta 13)
git cherry-pick -S e10c2c0a3c2b6e74242510277bc6fa5897af5d2d
git cherry-pick -S 43a95667b4428a5718c7e328338b3d00650f0916
```